### PR TITLE
Dockerfile: use less RUN statements and use only apt-get.

### DIFF
--- a/docker/CGO_NOELLE_dockerfile
+++ b/docker/CGO_NOELLE_dockerfile
@@ -1,27 +1,22 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt search cmake
-RUN apt-get install -y curl
-RUN apt-get update
-RUN apt remove --purge --auto-remove gcc g++
-RUN apt-get install -y vim make binutils wget  gawk sed  zlib1g-dev build-essential libtool autoconf unzip gcc-8 g++-8 bc time
-RUN apt-get install -y libllvm-9-ocaml-dev libllvm9 llvm-9 llvm-9-dev llvm-9-doc llvm-9-examples llvm-9-runtime
-RUN apt-get install -y clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 clangd-9 
-RUN apt-get update
-#RUN apt-get install -y cmake
-RUN apt remove --purge --auto-remove cmake
-RUN apt update
-RUN apt install -y software-properties-common lsb-release
-RUN apt clean all
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - |  tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-RUN apt update
-RUN apt install -y cmake
-RUN apt-get install -y golang git
+RUN apt-get install -y curl software-properties-common lsb-release git wget vim sed binutils gawk bc time unzip \
+      make zlib1g-dev build-essential libtool autoconf gcc-8 g++-8 \
+      libllvm-9-ocaml-dev libllvm9 llvm-9 llvm-9-dev llvm-9-doc llvm-9-examples llvm-9-runtime \
+      clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 clangd-9 \
+      golang
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
+RUN apt-get remove --purge --auto-remove cmake \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - |  tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+    && apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
+    && apt-get update \
+    && apt-get install -y cmake
+
+RUN apt-get clean -y
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
 
 RUN useradd --create-home --shell /bin/bash cgo22ae
 


### PR DESCRIPTION
- Removed superfluous 'apt-get update' commands.
- Combined multiple RUN apt-get install statements into one. Only where it made sense. Organization was preserved.
- Instances of using 'apt' were fixed to use 'apt-get'