### PR TITLE
Added a prompt to compileAndRun to use Condor

### DIFF
--- a/bin/compileAndRun
+++ b/bin/compileAndRun
@@ -1,5 +1,40 @@
 #!/bin/bash -e
 
+while [[ $# -gt 0 ]] ;
+do
+    case $1 in
+        -y)
+            useCondorChoice="y"
+            shift
+            ;;
+        -n)
+            useCondorChoice="n"
+            shift
+            ;;
+        *)
+            echo "Unknown option $1" ;
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${useCondorChoice+x}" ]  ; then
+    if [[ "$(hostname)" =~ ^peroni\..*$ ]] ; then
+        read -p "Looks like you're on peroni, would you like to run with Condor? [Y/n] " useCondorChoice ;
+        useCondorChoice=${useCondorChoice:-"y"} ;
+        if [[ ! "${useCondorChoice}" =~ ^[NnYy]$ ]] ; then
+            echo "Unknown selection ${useCondorChoice}" ;
+            exit 1 ;
+        fi
+    fi
+fi
+
+if [[ "${useCondorChoice}" =~ ^[Yy]$ ]] ; then
+    runSuffix="Condor" ;
+else
+    runSuffix="" ;
+fi
+
 prefixString="### NOELLE Gym ###" ;
 echo "${prefixString} All benchmarks from all benchmark suites will be compiled, run, and statistics will be collected" ;
 echo "${prefixString} Results will be stored in `pwd`/results/current_machine" ;
@@ -23,7 +58,7 @@ echo "${prefixString}   Compute statistics" ;
 
 # Run the binaries
 echo "${prefixString}   Run binaries" ;
-./bin/run >> output.txt 2>&1 ;
+./bin/run${runSuffix} >> output.txt 2>&1 ;
 
 # Clean
 echo "${prefixString}   Clean" ;


### PR DESCRIPTION
There have been a few instances of folks performing noelleGym runs on peroni rather than condor. Most of them said they were just blindly doing compileAndRun, which invoke run instead of runCondor.

This PR adds the following functionality to `bin/compileAndRun`:
1. Checks if the user is on peroni using `hostname`, if they are then it will prompt them, asking if they'd like to run on condor.
2. Adds `-y` and `-n` command line options to select yes or no without the prompt.
3. Does not impact the workflow of users who are not on peroni (unless their hostname starts with `peroni.`, but this can be changed to check for the full hostname instead, but I didn't want to publish that)