### PR TITLE
Fix compile condor

### DIFF
--- a/bin/compileAndRun
+++ b/bin/compileAndRun
@@ -59,7 +59,7 @@ else
   ./bin/compile >> output.txt 2>&1 ;
 fi
 
-# # Compute statistics
+# Compute statistics
 echo "${prefixString}   Compute statistics" ;
 if [[ $useCondor = true ]] ; then
   logFile=$(./bin/submitCondor "default" "bin/statistics" "''" "output.txt");
@@ -74,6 +74,7 @@ if [[ $useCondor = true ]] ; then
   ./bin/runCondor "piraat" >> output.txt 2>&1 ;
   logFiles=`ls log/condor/condor_*.log` ;
   ./bin/condorWait ${logFiles} >> output.txt 2>&1 ;
+  ./bin/plot >> output.txt 2>&1 ;
 else
   ./bin/run >> output.txt 2>&1 ;
 fi

--- a/bin/compileAndRun
+++ b/bin/compileAndRun
@@ -71,10 +71,8 @@ fi
 # Run the binaries
 echo "${prefixString}   Run binaries" ;
 if [[ $useCondor = true ]] ; then
-  ./bin/runCondor "piraat" >> output.txt 2>&1 ;
-  logFiles=`ls log/condor/condor_*.log` ;
-  ./bin/condorWait ${logFiles} >> output.txt 2>&1 ;
-  ./bin/plot >> output.txt 2>&1 ;
+  logFile=$(./bin/submitCondor "piraat" "bin/run" "''" "output.txt");
+  ./bin/condorWait ${logFile} >> output.txt 2>&1 ;
 else
   ./bin/run >> output.txt 2>&1 ;
 fi

--- a/scripts/misc.sh
+++ b/scripts/misc.sh
@@ -88,12 +88,12 @@ function compile_benchmark {
   cp ${origDir}/results/current_machine/IR/${suiteOfBench}/benchmarks/${benchToOptimize}/baseline_with_metadata.bc benchmarks/${benchToOptimize}/ ;
 
   # Check if there is a benchmark-specific makefile
-  if test -f ${origDir}/makefiles/${suite}/${optimizationName}/${benchToOptimize}/Makefile ; then
-    cp ${origDir}/makefiles/${suite}/${optimizationName}/${benchToOptimize}/* makefiles/ ;
+  if test -f ${origDir}/makefiles/${suiteOfBench}/${optimizationName}/${benchToOptimize}/Makefile ; then
+    cp ${origDir}/makefiles/${suiteOfBench}/${optimizationName}/${benchToOptimize}/* makefiles/ ;
   else
 
     # Copy the optimization-specific makefile
-    cp ${origDir}/makefiles/${suite}/${optimizationName}/* makefiles/ ;
+    cp ${origDir}/makefiles/${suiteOfBench}/${optimizationName}/* makefiles/ ;
   fi
 
   # The benchmark needs to be optimized


### PR DESCRIPTION
1. fix variable name issues in `scripts/misc.sh`.
   - `compile_benchmark()` uses both `${suiteOfBench}` and `${suite}` to refer to benchsuite names. `${suite}` is not declared.
   - The issue isn't triggered by the sequential scripts because the caller `scripts/optimize_benchmarks.sh` happens to declare `${suite}` as well.
2. Submitting `bin/run` to condor to replace the incorrect `bin/runCondor`.
   -  `bin/runCondor` will submit 6 condor jobs (baseline and 5 parallelizations), each one invokes `"bin/runTechnique HELIX"` or other parallelizations.
   - `bin/runTechnique HELIX` will copy `current_machine/.../2mm/baseline_parallelized_HELIX.bc` into `all_benchmark_suites/.../2mm/2mm.bc`. The target file name **repiles only on the benchmark name** instead of the parallelization.
   - Basically, the 6 condor jobs keep writing and executing the same target file(s) in `all_benchmark_suites`. This is the source of problems.